### PR TITLE
Update MacOS installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ $ wget -qO- https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.ta
 ```
 
 Access to `usr/bin` is restricted after Catalina 2019. A semi-secure work around is to create a new bin folder (in home directory for example) and link to PATH:
-*Feel free to use wget instead of curl
+\*Feel free to use wget instead of curl
+\*Add export path line to `.bashrc` for OS X or `.zshrc` for perminant usage
 
 ```
 $ mkdir ~/bin
-$ export PATH=".:${HOME}/bin:${PATH}" 
+$ export PATH="${HOME}/bin:${PATH}" 
 $ curl -sL https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.tar | tar x -C ~/bin/
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Access to `usr/bin` is restricted after Catalina 2019. A semi-secure work around
 $ mkdir ~/bin
 $ export PATH="${HOME}/bin:${PATH}" 
 $ curl -sL https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.tar | tar x -C ~/bin/
+$ chmod -R go-w ${HOME}/bin
 ```
 
 ## Config file

--- a/README.md
+++ b/README.md
@@ -30,13 +30,21 @@ $ sudo wget -qO- https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-lin
 ### On MacOS
 ```
 $ curl -sL https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.tar | tar x -C /usr/local/bin/
-
 ```
 
 Or with wget:
 
 ```
 $ wget -qO- https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.tar | tar x -C /usr/local/bin/
+```
+
+Access to `usr/bin` is restricted after Catalina 2019. A semi-secure work around is to create a new bin folder (in home directory for example) and link to PATH:
+*Feel free to use wget instead of curl
+
+```
+$ mkdir ~/bin
+$ export PATH=".:${HOME}/bin:${PATH}" 
+$ curl -sL https://github.com/onilton/ogl/releases/download/v0.0.2/ogl-macos.tar | tar x -C ~/bin/
 ```
 
 ## Config file


### PR DESCRIPTION
The MacOS restricts access to bin folder by default. 

Source for solution: 
https://discussions.apple.com/thread/254996951?sortBy=best

Added instructions in readme for quick fix. 

Fixes #15 

NOTE: The latest release of this package is from 2019. MacOS created the restriction that year; therefore, the issue wasn't a concern back then. 